### PR TITLE
Fixing numeric links in blog pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 # Site Settings
+# Do not use trailing slash (i.e. "/Sample"). For skipping base URL, leave empty quotes ("")
 baseurl: "/Grape-Academic-Theme"
 
 # Features Setting

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -33,7 +33,7 @@ layout: page
                 </span>
                 <ul class="tag-wrap">
                   {% for tag in post.tags %}
-                  <a href="{{site.baseurl}}/tags#{{ tag | cgi_escape }}">
+                  <a href="{{ site.baseurl }}/tags#{{ tag | cgi_escape }}">
                     <li class="tag-sm">{{ tag }}</li>
                   </a>
                   {% endfor %}
@@ -63,20 +63,20 @@ layout: page
           {% assign max = paginator.total_pages %}
           {% endif %}
           {% if min != 1 %}
-          <a href="/blog/page{{ min | minus: 1 }}">
+          <a href="{{ site.baseurl }}/blog/page{{ min | minus: 1 }}">
             <li class="btn-rounded prev">
               <i class="fas fa-angle-double-left"></i>
             </li>
           </a>
           {% endif %}
           {% for page in (min..max) %}
-          <a href="{% if page == 1 %}/{% else %}/blog/page{{ page }}{% endif %}"
+          <a href="{% if page == 1 %}{{ site.baseurl }}/blog{% else %}{{ site.baseurl }}/blog/page{{ page }}{% endif %}"
             class="{% if page == paginator.page %}selected{% endif %}">
             <li class="btn-rounded">{{ page }}</li>
           </a>
           {% endfor %}
           {% if max != paginator.total_pages %}
-          <a href="/blog/page{{ max | plus: 1 }}">
+          <a href="{{ site.baseurl }}/blog/page{{ max | plus: 1 }}">
             <li class="btn-rounded next">
               <i class="fas fa-angle-double-right"></i>
             </li>


### PR DESCRIPTION
This is a fix for the following bug:
The blog pages do not take the baseurl into account. Example, the button to the second page points to `http://127.0.0.1:4000/blog/page2` instead of `http://127.0.0.1:4000/Grape-Academic-Theme/blog/page2`

This happens for all buttons in the blog pages, and it's critical for page 1.
I've tested the fix with and without a `baseurl`.

_This bug exists also in the original repo from @naye0ng, but that is no longer merging PRs since very long._